### PR TITLE
feat!: make .matches not require &mut self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,7 @@ impl Regex {
     }
 
     /// Returns an iterator over the matches.
-    pub fn matches<Haystack: Iterator<Item = u8>>(
-        &mut self,
-        haystack: Haystack,
-    ) -> Matches<Haystack> {
+    pub fn matches<Haystack: Iterator<Item = u8>>(&self, haystack: Haystack) -> Matches<Haystack> {
         Matches::new(self, haystack)
     }
 }


### PR DESCRIPTION
Currently, whilst the Matches::new function doesn't need &mut self, the .matches method still does. This PR fixes that.
